### PR TITLE
update(deps): upgrade all dependencies to January 2025 versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -8,19 +8,19 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.7
+    rev: v0.12.7
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.14.0
+    rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
         args: [--fix]
         exclude: ^CHANGELOG
   - repo: https://github.com/google/yamlfmt
-    rev: v0.13.0
+    rev: v0.15.0
     hooks:
       - id: yamlfmt
   - repo: https://github.com/pecigonzalo/pre-commit-shfmt

--- a/project/.pre-commit-config.yaml
+++ b/project/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-builtin-literals
       - id: check-added-large-files
@@ -13,22 +13,22 @@ repos:
       - id: check-docstring-first
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.4.15
+    rev: 0.8.5
     hooks:
       - id: pip-compile
         args: [requirements.in, -o, requirements.txt]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.17.1
     hooks:
       - id: mypy
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.7
+    rev: v0.12.7
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.14.0
+    rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
         args: [--fix]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -10,12 +10,12 @@ readme = "README.md"
 
 [tool.uv]
 dev-dependencies = [
-    "commitizen>=3.29.0",
+    "commitizen>=4.8.3",
     "invoke>=2.2.0",
-    "mkdocs-macros-plugin>=1.2.0",
-    "mkdocs-material>=9.5.37",
-    "mkdocstrings>=0.26.1",
-    "pre-commit>=3.8.0",
-    "pytest-cov>=5.0.0",
-    "pytest>=8.3.3",
+    "mkdocs-macros-plugin>=1.3.7",
+    "mkdocs-material>=9.6.16",
+    "mkdocstrings>=0.30.0",
+    "pre-commit>=4.2.0",
+    "pytest-cov>=6.2.1",
+    "pytest>=8.4.1",
 ]

--- a/project/tests/unit/test_import.py.jinja
+++ b/project/tests/unit/test_import.py.jinja
@@ -3,14 +3,14 @@ import pytest
 
 def test_import() -> None:
     try:
-        import {{ python_package_import_name }}  # noqa: F401
+        import {{ python_package_import_name }}  # noqa: F401, PLC0415
     except ImportError as err:
         pytest.fail(f"Failed to import {{ python_package_import_name }}: {err}")
 
 
 def test_import_version() -> None:
     try:
-        from {{ python_package_import_name }} import __version__  # noqa: F401
+        from {{ python_package_import_name }} import __version__  # noqa: F401, PLC0415
 
         assert __version__ == "0.0.1"
     except ImportError as err:


### PR DESCRIPTION
MAJOR UPDATES:
- commitizen: 3.29.0 → 4.8.3
- pre-commit: 3.8.0 → 4.2.0
- pytest-cov: 5.0.0 → 6.2.1
- ruff-pre-commit: v0.6.7 → v0.12.7 (breaking: ruff hook → ruff-check)

MINOR UPDATES:
- mkdocs-macros-plugin: 1.2.0 → 1.3.7
- mkdocs-material: 9.5.37 → 9.6.16
- mkdocstrings: 0.26.1 → 0.30.0
- pytest: 8.3.3 → 8.4.1
- pre-commit-hooks: v4.6.0 → v5.0.0
- markdownlint-cli2: v0.14.0 → v0.18.1
- yamlfmt: v0.13.0 → v0.15.0
- uv-pre-commit: 0.4.15 → 0.8.5
- mirrors-mypy: v1.11.2 → v1.17.1

FIXES:
- Add PLC0415 to noqa comments for new ruff rule
- Migrate ruff hook id from "ruff" to "ruff-check" (ruff v0.12 breaking change)